### PR TITLE
Add ability to log chore completions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { prisma } from "./db/prisma.js";
 import { healthRouter } from "./routes/health.js";
 import { usersRouter } from "./routes/users.js";
 import { choresRouter } from "./routes/chores.js";
+import { completionsRouter } from "./routes/completions.js";
 
 const app = express();
 
@@ -15,6 +16,7 @@ app.use(express.json());
 app.use(healthRouter);
 app.use(usersRouter);
 app.use(choresRouter);
+app.use(completionsRouter);
 
 app.get("/health/db", async (_req, res, next) => {
   try {
@@ -25,13 +27,22 @@ app.get("/health/db", async (_req, res, next) => {
   }
 });
 
-app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  console.error(err);
-  res.status(500).json({ error: "Internal Server Error" });
-});
+app.use(
+  (
+    err: unknown,
+    _req: express.Request,
+    res: express.Response,
+    _next: express.NextFunction,
+  ) => {
+    console.error(err);
+    res.status(500).json({ error: "Internal Server Error" });
+  },
+);
 
-const port= process.env.PORT ? Number(process.env.PORT) : 8787;
-app.listen(port, () => console.log(`API listening on http://localhost:${port}`));
+const port = process.env.PORT ? Number(process.env.PORT) : 8787;
+app.listen(port, () =>
+  console.log(`API listening on http://localhost:${port}`),
+);
 
 // Create a user
 app.post("/api/users", async (req, res) => {

--- a/apps/api/src/routes/completions.ts
+++ b/apps/api/src/routes/completions.ts
@@ -1,0 +1,80 @@
+import { Router } from "express";
+import { prisma } from "../db/prisma.js";
+
+export const completionsRouter = Router();
+
+// GET /completions?date=YYYY-MM-DD&userId=...
+
+completionsRouter.get("/completions", async (req, res, next) => {
+  try {
+    const { date, userId } = req.query as { date?: string; userId?: string };
+
+    const args: Parameters<typeof prisma.choreCompletion.findMany>[0] = {
+      include: { user: true, chore: true },
+      orderBy: { completedAt: "asc" },
+    };
+
+    const where: Record<string, any> = {};
+
+    if (typeof userId === "string" && userId.length > 0) {
+      where.userId = userId;
+    }
+
+    // If date provided, filter to that local-day window
+    if (typeof date === "string" && date.length > 0) {
+      const start = new Date(`${date}T00:00:00`);
+      const end = new Date(`${date}T23:59:59`);
+      where.completedAt = { gte: start, lte: end };
+    }
+
+    if (Object.keys(where).length > 0) {
+      args.where = where as any;
+    }
+
+    const completions = await prisma.choreCompletion.findMany(args);
+    res.json(completions);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /completions { userId, choreId, date }
+
+completionsRouter.post("/completions", async (req, res, next) => {
+  try {
+    const { userId, choreId, date } = req.body as {
+      userId?: unknown;
+      choreId?: unknown;
+      date?: unknown;
+    };
+
+    if (typeof userId !== "string" || userId.trim().length === 0) {
+      return res.status(400).json({ error: "userId is required" });
+    }
+    if (typeof choreId !== "string" || choreId.trim().length === 0) {
+      return res.status(400).json({ error: "choreId is required" });
+    }
+
+    let when = new Date();
+    if (typeof date === "string" && date.length > 0) {
+      const parsed = new Date(date);
+      if (Number.isNaN(parsed.getTime())) {
+        return res.status(400).json({ error: "invalid date" });
+      }
+      when = parsed;
+    }
+
+    const completion = await prisma.choreCompletion.create({
+      data: {
+        userId: userId.trim(),
+        choreId: choreId.trim(),
+        completedAt: when,
+      },
+      include: { user: true, chore: true },
+    });
+
+    res.status(201).json(completion);
+  } catch (err) {
+    next(err);
+  }
+});

--- a/apps/web/src/pages/LogCompletionPage.tsx
+++ b/apps/web/src/pages/LogCompletionPage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { api } from "../lib/api.js";
+
+type User = { id: string; name: string };
+type Chore = { id: string; title: string };
+type Completion = {
+  id: string;
+  completedAt: string;
+  user: User;
+  chore: Chore;
+};
+
+export function LogCompletionPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [chores, setChores] = useState<Chore[]>([]);
+  const [completions, setCompletions] = useState<Completion[]>([]);
+  const [userId, setUserId] = useState("");
+  const [choreId, setChoreId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // load user + chores + today's completions
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      try {
+        const [u, c, comps] = await Promise.all([
+          api<User[]>("/users"),
+          api<Chore[]>("/chores?active=true"),
+          api<Completion[]>(
+            `/completions?date=${new Date().toISOString().slice(0, 10)}`,
+          ),
+        ]);
+
+        if (!cancelled) {
+          setUsers(u);
+          setChores(c);
+          setCompletions(comps);
+        }
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      }
+    }
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function logCompletion() {
+    if (!userId || !choreId) {
+      setError("Select both a user and a chore.");
+      return;
+    }
+
+    try {
+      setError(null);
+      const newCompletion = await api<Completion>("/completions", {
+        method: "POST",
+        body: JSON.stringify({ userId, choreId }),
+      });
+
+      setCompletions((prev) => [...prev, newCompletion]);
+      setChoreId("");
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 700, margin: "0 auto", padding: 16 }}>
+      <h1>Log Chore Completions</h1>
+
+      {error && (
+        <div style={{ border: "1px solid", padding: 8, marginBottom: 12 }}>
+          {error}
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        <select value={userId} onChange={(e) => setUserId(e.target.value)}>
+          <option value="">Select user</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.name}
+            </option>
+          ))}
+        </select>
+
+        <select value={choreId} onChange={(e) => setChoreId(e.target.value)}>
+          <option value="">Select Chore</option>
+          {chores.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.title}
+            </option>
+          ))}
+        </select>
+
+        <button onClick={logCompletion}>Log</button>
+      </div>
+
+      <h2>Today</h2>
+      <ul>
+        {completions.map((c) => (
+          <li key={c.id}>
+            {c.user.name} - {c.chore.title}
+          </li>
+        ))}
+        {completions.length === 0 && <li>No completions yet.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #9 

This adds end-to-end support for logging chore completions.

### What’s included

**API**
- New `/completions` routes:
  - `POST /completions` — log a completion for a user + chore (optional date)
  - `GET /completions` — query by date and/or user
- Uses `completedAt` (per schema) and includes related `user` and `chore` in responses
- Matches existing error-handling and validation patterns

**Web**
- New `LogCompletionPage`:
  - Select a user and an active chore
  - Log a completion
  - Shows today’s logged completions in a simple list
- Reuses the existing API helper (`api()`)

### Testing
- Verified manually via:
  - `curl` against `/completions`
  - UI flow in the browser (log + refresh persistence)

This completes the MVP “log chore completions” slice.
